### PR TITLE
Compatible with electron3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ const commonjsExternalsPlugin = ({
       }
 
       const requireStatement = (identifiers: string) =>
-        `const ${identifiers}=(()=>{const mod = require("${node.source.value}");return mod?.__esModule ? mod : Object.assign(Object.create(null),mod,{default:mod,[Symbol.toStringTag]:"Module"})})();`;
+        `const ${identifiers}=(()=>{const mod = require("${node.source.value}");return mod && mod.__esModule ? mod : Object.assign(Object.create(null),mod,{default:mod,[Symbol.toStringTag]:"Module"})})();`;
       const localNamesIdentifiers = [
         ...importSpecifierList.map(
           spec => `${spec.imported.name}: ${spec.local.name}`


### PR DESCRIPTION
你好，我使用`electron3`开发，使用该包后发现不支持 `?.` 语法，程序无法运行。希望把 `mod?.__esModule`  改成 `mod && mod.__esModule`以支持低版本 `electron`，谢谢！